### PR TITLE
Fix oj dump

### DIFF
--- a/lib/simple_representer/collection.rb
+++ b/lib/simple_representer/collection.rb
@@ -18,7 +18,7 @@ module SimpleRepresenter
     alias to_hash to_h
 
     def to_json(*_args)
-      ::Oj.generate(to_h)
+      ::Oj.dump(to_h, { mode: :compat })
     end
   end
 end

--- a/lib/simple_representer/representer.rb
+++ b/lib/simple_representer/representer.rb
@@ -26,7 +26,7 @@ module SimpleRepresenter
     alias to_hash to_h
 
     def to_json(*_args)
-      ::Oj.generate(to_h)
+      ::Oj.dump(to_h, { mode: :compat })
     end
 
     def self.for_collection(collection, **options)


### PR DESCRIPTION
According to OJ docs, about `.generate`:

```
Calling this method will call Oj.mimic_JSON if it is not already called.
```

To avoid that, let's just use dump with mode argument