### PR TITLE
Support render unless key not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ property :name, default: 'Paladin'
 - `render_nil` to render or skip nil value (default is false):
 ```ruby
 # will render { name: nil } if name is nil
+```
+- `render_if_key_found` to render or skip if key not found (default is false):
+```ruby
 property :name, render_nil: true
 ```
 - `representer` to use different representer for nested objects.

--- a/lib/simple_representer/field.rb
+++ b/lib/simple_representer/field.rb
@@ -10,6 +10,8 @@ module SimpleRepresenter
     end
 
     def call(representer)
+      @representer = representer
+
       return if options[:if] && !representer.instance_exec(&options[:if])
 
       value = process(representer)
@@ -21,6 +23,8 @@ module SimpleRepresenter
 
     private
 
+    attr_reader :representer
+
     def nested_representer(value)
       return options[:representer].for_collection(value).to_h if value.is_a?(Array)
 
@@ -29,6 +33,7 @@ module SimpleRepresenter
 
     def build_field(value)
       return if value.nil? && !options.fetch(:render_nil, false)
+      return if value.nil? && options.fetch(:render_if_key_found, false) && !representer.represented.respond_to?(field)
 
       [(options[:as] || field).to_sym, value]
     end

--- a/spec/simple_representer/simple_representer/definable_spec.rb
+++ b/spec/simple_representer/simple_representer/definable_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe SimpleRepresenter::Definable do
     include SimpleRepresenter::Definable
 
     defaults render_nil: true
+    defaults render_if_key_found: true
 
     property :name, if: -> { true }
     computed :id, as: :uid
@@ -17,9 +18,9 @@ RSpec.describe SimpleRepresenter::Definable do
     expect(subject.size).to eq(2)
     expect(subject[0]).to be_kind_of(SimpleRepresenter::Property)
     expect(subject[0].field).to eq(:name)
-    expect(subject[0].options.keys).to include(:if, :render_nil)
+    expect(subject[0].options.keys).to include(:if, :render_nil, :render_if_key_found)
     expect(subject[1]).to be_kind_of(SimpleRepresenter::Computed)
     expect(subject[1].field).to eq(:id)
-    expect(subject[1].options).to eq({ as: :uid, render_nil: true })
+    expect(subject[1].options).to eq({ as: :uid, render_nil: true, render_if_key_found: true })
   end
 end

--- a/spec/simple_representer/simple_representer/property_spec.rb
+++ b/spec/simple_representer/simple_representer/property_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require_relative '../../../lib/simple_representer/representer'
 require_relative '../../../lib/simple_representer/property'
 
 RSpec.describe SimpleRepresenter::Property do
@@ -82,6 +83,27 @@ RSpec.describe SimpleRepresenter::Property do
 
     context 'should render nil field if render_nil is true' do
       let(:options) { { render_nil: true } }
+      it { is_expected.to eq([:name, nil]) }
+    end
+  end
+
+  context 'with render_if_key_found option' do
+    let(:representer) { double({ represented: OpenStruct.new(name: 'Paladin') }) }
+
+    context 'should render field if key is found by default' do
+      let(:options) { {} }
+      it { is_expected.to eq([:name, 'Paladin']) }
+    end
+
+    context 'should not render field if render_if_key_found is true' do
+      let(:representer) { double({ represented: OpenStruct.new(inside_name: 'Paladin') }) }
+      let(:options) { { render_if_key_found: true, render_nil: true } }
+      it { is_expected.to eq(nil) }
+    end
+
+    context 'should render field if render_if_key_found is false' do
+      let(:representer) { double({ represented: OpenStruct.new(inside_name: 'Paladin') }) }
+      let(:options) { { render_if_key_found: false, render_nil: true } }
       it { is_expected.to eq([:name, nil]) }
     end
   end

--- a/spec/simple_representer/simple_representer/representer_spec.rb
+++ b/spec/simple_representer/simple_representer/representer_spec.rb
@@ -5,6 +5,7 @@ require_relative '../../../lib/simple_representer/representer'
 RSpec.describe SimpleRepresenter::Representer do
   class CompanyRepresenter < SimpleRepresenter::Representer
     defaults render_nil: true
+    defaults render_if_key_found: false
     property :name
   end
 


### PR DESCRIPTION
render_if_key_found:

"This option or method supports rendering only if the specified key is found in the hash. If the key is not found, rendering will be skipped."

@wojtowicz 

Currently the representer will return defined property with nil value even if there isn't key passed from represented. 
For example
```
class SimpleRepresenter
   property :name
   property :title
end

SimpleRepresenter.new({ title: "Paladin" })

output:
{ name: "", title: "Paladin" }
```

so I expect to have an option to remove defined properly when the represented doesn't have that key
expected output:
`{ title: "Paladin" }`